### PR TITLE
Adjusted time selection to automatically calculate duration

### DIFF
--- a/DataModels/Movie.cs
+++ b/DataModels/Movie.cs
@@ -7,9 +7,10 @@ public class Movie
     public double Price { get; set; }
     public string Duration { get; set; }
     public string Description { get; set; }
-    public string Showtimes { get; set; }  
-    public string Cast { get; set; }       
-    public bool IsPlaying { get; set; }    
+    public string Showtimes { get; set; }
+    public string Cast { get; set; }
+    public bool IsPlaying { get; set; }
+    public int LengthInMinutes { get; set; }
 
     public Movie(string title, string genre, string director, double rating, double price, string duration, string description, string showtimes, string cast, bool isPlaying)
     {

--- a/Logic/CreateScheduledShow.cs
+++ b/Logic/CreateScheduledShow.cs
@@ -69,8 +69,15 @@ class Schedule
         string MovieName = ScheduleMovieName();
 
         DateTime StartDate = GetDateTime();
+        List<Movie> MoviesList = AccessData.ReadMoviesJson();
+        int lengthinminutes = 0;
+        foreach (Movie movie in MoviesList)
+        {
+            if (movie.Title == MovieName)
+                lengthinminutes = movie.LengthInMinutes;
+        }
 
-        DateTime EndDate = GetDateTime();
+        DateTime EndDate = StartDate.AddMinutes(lengthinminutes);
 
         string filenameDateTimeString = StartDate.ToString("yyyyMMdd_HHmmss");
         string finalName = $"{MovieName}-{filenameDateTimeString}";


### PR DESCRIPTION
When scheduling a movie it only requires you to input the start date / time and it will automatically calculate the end time. No more double inputs required. It takes a new attribute "LengthInMinutes" from movies.json. Linked to the same variable in movie class.